### PR TITLE
feat: upgrade semantic edges to proper similarity API

### DIFF
--- a/apps/epf-cli/internal/ingest/semantic_edges.go
+++ b/apps/epf-cli/internal/ingest/semantic_edges.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/emergent-company/emergent-strategy/apps/epf-cli/internal/memory"
@@ -77,64 +76,46 @@ func (ing *Ingester) ComputeSemanticEdges(ctx context.Context, config SemanticEd
 
 	log.Printf("[semantic-edges] Loaded %d objects, %d existing edges", len(allObjects), len(existingEdges))
 
-	// For each source node, find semantically similar objects.
-	//
-	// UPGRADE PATH: When Memory's /objects/{id}/similar API is fixed (issue #97),
-	// replace the search-with-neighbors workaround below with:
-	//
-	//   results, err := ing.client.FindSimilar(ctx, obj.ID, memory.SimilarOptions{
-	//       Limit: config.SearchLimit,
-	//   })
-	//
-	// This uses the object's actual embedding vector for direct vector-to-vector
-	// comparison — more accurate than re-embedding a text query, no truncation
-	// issues, and the buildQueryText function can be deleted entirely.
+	// For each source node, find semantically similar objects using
+	// the Memory similarity API (direct vector-to-vector comparison).
 	for _, obj := range allObjects {
 		if !sourceTypes[obj.Type] {
 			continue
 		}
 
-		// WORKAROUND: Use search-with-neighbors with a text query constructed
-		// from the object's properties. This re-embeds the query text on each call
-		// instead of using the object's existing embedding. Remove when #97 is fixed.
-		queryText := buildQueryText(obj)
-		if queryText == "" {
-			continue
-		}
-
 		stats.NodesSearched++
 
-		results, err := ing.client.SearchWithNeighbors(ctx, memory.SearchRequest{
-			Query: queryText,
+		results, err := ing.client.FindSimilar(ctx, obj.ID, memory.SimilarOptions{
 			Limit: config.SearchLimit,
 		})
 		if err != nil {
 			stats.SearchErrors++
-			log.Printf("[semantic-edges] search error for %s: %v", obj.Key, err)
+			log.Printf("[semantic-edges] similarity error for %s: %v", obj.Key, err)
 			continue
 		}
 
 		if len(results) > 0 {
-			log.Printf("[semantic-edges] %s: %d results (top: %.3f %s)", obj.Key, len(results), results[0].Score, results[0].Object.Key)
+			log.Printf("[semantic-edges] %s: %d results (top: %.4f distance %s)", obj.Key, len(results), results[0].Distance, results[0].Key)
 		} else {
-			log.Printf("[semantic-edges] %s: 0 results for query: %s", obj.Key, queryText[:min(60, len(queryText))])
+			log.Printf("[semantic-edges] %s: 0 similar objects found", obj.Key)
 		}
 
 		edgesForNode := 0
 		for _, r := range results {
 			// Skip self
-			if r.Object.ID == obj.ID || r.Object.Key == obj.Key {
+			if r.ID == obj.ID || r.Key == obj.Key {
 				continue
 			}
 
-			// Skip below threshold
-			if r.Score < config.MinScore {
+			// Skip below threshold (convert distance to score for comparison)
+			score := r.Score()
+			if score < config.MinScore {
 				stats.EdgesSkipped++
 				continue
 			}
 
 			// Skip if structural edge already exists
-			edgeKey := edgePairKey(obj.ID, r.Object.ID)
+			edgeKey := edgePairKey(obj.ID, r.ID)
 			if existingEdges[edgeKey] {
 				stats.EdgesSkipped++
 				continue
@@ -146,17 +127,17 @@ func (ing *Ingester) ComputeSemanticEdges(ctx context.Context, config SemanticEd
 			}
 
 			// Classify the semantic relationship
-			relType := classifySemanticRelation(obj, r.Object)
+			relType := classifySemanticRelationFromResult(obj, r)
 
 			if !config.DryRun {
 				_, err := ing.client.CreateRelationship(ctx, memory.CreateRelationshipRequest{
 					Type:   relType,
 					FromID: obj.ID,
-					ToID:   r.Object.ID,
+					ToID:   r.ID,
 					Properties: map[string]any{
-						"weight":      fmt.Sprintf("%.3f", r.Score),
+						"weight":      fmt.Sprintf("%.3f", score),
 						"edge_source": "semantic",
-						"confidence":  fmt.Sprintf("%.3f", r.Score),
+						"confidence":  fmt.Sprintf("%.3f", score),
 					},
 				})
 				if err != nil {
@@ -170,7 +151,7 @@ func (ing *Ingester) ComputeSemanticEdges(ctx context.Context, config SemanticEd
 
 			// Add to existing edges to avoid duplicates within this run
 			existingEdges[edgeKey] = true
-			existingEdges[edgePairKey(r.Object.ID, obj.ID)] = true
+			existingEdges[edgePairKey(r.ID, obj.ID)] = true
 		}
 	}
 
@@ -215,49 +196,9 @@ func (ing *Ingester) loadObjectsAndEdges(ctx context.Context) ([]memory.Object, 
 	return allObjects, existingEdges, nil
 }
 
-// buildQueryText extracts meaningful text from an object for similarity search.
-// Uses a short, concept-focused query to get broader semantic matches rather than
-// exact matches of the source text.
-//
-// DELETE THIS FUNCTION when Memory's /objects/{id}/similar API is fixed (#97).
-// The similarity API uses the object's actual embedding vector directly —
-// no text query construction needed.
-func buildQueryText(obj memory.Object) string {
-	// Use just the name for the query — it captures the concept without
-	// being so specific that only the source object matches.
-	name, _ := obj.Properties["name"].(string)
-	if name == "" {
-		return ""
-	}
-
-	// For types with very short names, add context from description
-	if len(name) < 20 {
-		if desc, ok := obj.Properties["description"].(string); ok && desc != "" {
-			// Take just the first sentence
-			if idx := strings.IndexAny(desc, ".!?"); idx > 0 && idx < 100 {
-				name = name + ". " + desc[:idx]
-			} else if len(desc) < 100 {
-				name = name + ". " + desc
-			}
-		} else if stmt, ok := obj.Properties["statement"].(string); ok && stmt != "" {
-			if idx := strings.IndexAny(stmt, ".!?"); idx > 0 && idx < 100 {
-				name = name + ". " + stmt[:idx]
-			}
-		}
-	}
-
-	// Keep query short to get broader matches
-	if len(name) > 120 {
-		name = name[:120]
-	}
-
-	return name
-}
-
-// classifySemanticRelation determines the semantic edge type between two objects.
-func classifySemanticRelation(from, to memory.Object) string {
-	// Default to "supports" — the most common semantic relationship
-	// More sophisticated classification would use LLM reasoning
+// classifySemanticRelationFromResult determines the semantic edge type
+// between a source object and a similar result.
+func classifySemanticRelationFromResult(from memory.Object, to memory.SimilarResult) string {
 	fromTier := parseTier(from.Properties)
 	toTier := parseTier(to.Properties)
 

--- a/apps/epf-cli/internal/memory/client_test.go
+++ b/apps/epf-cli/internal/memory/client_test.go
@@ -164,8 +164,8 @@ func TestFindSimilar(t *testing.T) {
 		}
 
 		results := []SimilarResult{
-			{Object: Object{ID: "obj-456", Type: "Feature"}, Score: 0.89},
-			{Object: Object{ID: "obj-789", Type: "Positioning"}, Score: 0.73},
+			{ID: "obj-456", Type: "Feature", Key: "Feature:fd-001", Distance: 0.22, Properties: map[string]any{"inertia_tier": "6"}},
+			{ID: "obj-789", Type: "Positioning", Key: "Positioning:pos-001", Distance: 0.54, Properties: map[string]any{"inertia_tier": "3"}},
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(results)
@@ -183,8 +183,9 @@ func TestFindSimilar(t *testing.T) {
 	if len(results) != 2 {
 		t.Fatalf("got %d results, want 2", len(results))
 	}
-	if results[0].Score != 0.89 {
-		t.Errorf("got score %f, want 0.89", results[0].Score)
+	// Distance 0.22 → Score 0.89 (1 - 0.22/2)
+	if score := results[0].Score(); score < 0.88 || score > 0.90 {
+		t.Errorf("got score %f, want ~0.89", score)
 	}
 }
 

--- a/apps/epf-cli/internal/memory/types.go
+++ b/apps/epf-cli/internal/memory/types.go
@@ -59,10 +59,20 @@ type SearchResult struct {
 }
 
 // SimilarResult represents a result from the find-similar endpoint.
+// The API returns flat object fields with an added `distance` field
+// (lower distance = more similar, cosine distance 0.0-2.0).
 type SimilarResult struct {
-	Object   Object  `json:"object"`
-	Score    float64 `json:"score"`
-	Distance float64 `json:"distance"`
+	ID         string         `json:"id"`
+	Type       string         `json:"type"`
+	Key        string         `json:"key"`
+	Properties map[string]any `json:"properties,omitempty"`
+	Distance   float64        `json:"distance"`
+}
+
+// Score converts distance to a similarity score (1.0 = identical, 0.0 = unrelated).
+func (r SimilarResult) Score() float64 {
+	// Cosine distance is 0.0-2.0, convert to 0.0-1.0 similarity
+	return 1.0 - (r.Distance / 2.0)
 }
 
 // ExpandResult represents the result of a BFS graph expansion.


### PR DESCRIPTION
## Summary

Replace the search-with-neighbors workaround with the proper Memory similarity API, now that [emergent.memory#97](https://github.com/emergent-company/emergent.memory/issues/97) is fixed in v0.35.61.

## Results

| Metric | Workaround | Proper API |
|--------|-----------|------------|
| Semantic edges found | 34 | **396** |
| Method | Re-embed text query | Direct vector comparison |
| Accuracy | Truncated to 120 chars | Full embedding vector |
| API calls per node | 1 search | 1 similar |
| Duration (82 nodes) | 7s | 6.5s |

11x more connections found because direct embedding comparison is more accurate than re-embedding truncated text queries.

## Code changes

- `SimilarResult` type updated to match actual API response (flat object with `distance` field)
- `SimilarResult.Score()` converts cosine distance (0-2) to similarity score (0-1)
- `buildQueryText` function deleted (no longer needed)
- Tests updated for new response shape