### PR TITLE
fix(memory): update schema API clients after template-pack → schemas rename

### DIFF
--- a/apps/epf-cli/internal/memory/schemas.go
+++ b/apps/epf-cli/internal/memory/schemas.go
@@ -25,9 +25,9 @@ type SchemaInfo struct {
 	Author  string `json:"author"`
 }
 
-// schemasProjectPath returns the project-scoped template pack API base path.
+// schemasProjectPath returns the project-scoped schema API base path.
 func (c *Client) schemasProjectPath() string {
-	return "/api/template-packs/projects/" + url.PathEscape(c.projectID)
+	return "/api/schemas/projects/" + url.PathEscape(c.projectID)
 }
 
 // ListInstalledSchemas returns schemas installed in the project.
@@ -43,13 +43,13 @@ func (c *Client) ListInstalledSchemas(ctx context.Context) ([]InstalledSchema, e
 // If merge is true, it additively merges types into the project.
 //
 // This is a two-step process:
-//  1. Create the schema in the org registry via POST /api/template-packs
-//  2. Assign it to the project via POST /api/template-packs/projects/{pid}/assign
+//  1. Create the schema in the org registry via POST /api/schemas
+//  2. Assign it to the project via POST /api/schemas/projects/{pid}/assign
 func (c *Client) InstallSchemaFromJSON(ctx context.Context, packJSON []byte, merge bool) error {
 	// Step 1: Create the schema in the org registry.
 	var pack json.RawMessage = packJSON
 	var created SchemaInfo
-	if err := c.do(ctx, "POST", "/api/template-packs", &pack, &created); err != nil {
+	if err := c.do(ctx, "POST", "/api/schemas", &pack, &created); err != nil {
 		return fmt.Errorf("create schema: %w", err)
 	}
 
@@ -57,14 +57,16 @@ func (c *Client) InstallSchemaFromJSON(ctx context.Context, packJSON []byte, mer
 		return fmt.Errorf("create schema: API returned empty schema ID")
 	}
 
-	// Step 2: Assign the schema to the project.
+	// Step 2: Assign the schema to the project. The merge flag must be in the
+	// request body: the endpoint binds AssignPackRequest from the POST body and
+	// ignores query parameters.
 	assignBody := map[string]any{
 		"schema_id": created.ID,
 	}
-	endpoint := c.schemasProjectPath() + "/assign"
 	if merge {
-		endpoint += "?merge=true"
+		assignBody["merge"] = true
 	}
+	endpoint := c.schemasProjectPath() + "/assign"
 	if err := c.do(ctx, "POST", endpoint, assignBody, nil); err != nil {
 		return fmt.Errorf("assign schema %s to project: %w", created.ID, err)
 	}

--- a/apps/strategy-server/internal/memory/client_test.go
+++ b/apps/strategy-server/internal/memory/client_test.go
@@ -327,7 +327,7 @@ func TestCreateRelationship(t *testing.T) {
 func TestListInstalledSchemas(t *testing.T) {
 	want := []InstalledSchema{{ID: "s-1", Name: "epf-core", Version: "1.0"}}
 	c := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/template-packs/projects/test-project/installed" {
+		if r.URL.Path != "/api/schemas/projects/test-project/installed" {
 			t.Errorf("path = %s, want project-scoped path", r.URL.Path)
 		}
 		w.WriteHeader(200)
@@ -343,6 +343,42 @@ func TestListInstalledSchemas(t *testing.T) {
 	}
 	if got[0].Name != "epf-core" {
 		t.Errorf("name = %q, want %q", got[0].Name, "epf-core")
+	}
+}
+
+func TestInstallSchema(t *testing.T) {
+	var assignPath string
+	var assignBody map[string]any
+	c := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/schemas":
+			w.WriteHeader(201)
+			_, _ = w.Write([]byte(`{"id":"s-1"}`))
+		case "/api/schemas/projects/test-project/assign":
+			assignPath = r.URL.String()
+			_ = json.NewDecoder(r.Body).Decode(&assignBody)
+			w.WriteHeader(201)
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+			w.WriteHeader(404)
+		}
+	}))
+
+	err := c.InstallSchema(context.Background(), InstallSchemaRequest{Name: "epf-core", Schema: map[string]any{}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// merge must travel in the request body: the assign endpoint binds
+	// AssignPackRequest from the POST body and ignores query parameters.
+	if assignPath != "/api/schemas/projects/test-project/assign" {
+		t.Errorf("assign path = %q, want no query parameters", assignPath)
+	}
+	if got, ok := assignBody["schema_id"].(string); !ok || got != "s-1" {
+		t.Errorf("assign body schema_id = %v, want %q", assignBody["schema_id"], "s-1")
+	}
+	if got, ok := assignBody["merge"].(bool); !ok || !got {
+		t.Errorf("assign body merge = %v, want true", assignBody["merge"])
 	}
 }
 

--- a/apps/strategy-server/internal/memory/schemas.go
+++ b/apps/strategy-server/internal/memory/schemas.go
@@ -8,7 +8,7 @@ import (
 
 // ListInstalledSchemas returns the schemas installed in the current project.
 func (c *Client) ListInstalledSchemas(ctx context.Context) ([]InstalledSchema, error) {
-	path := fmt.Sprintf("/api/template-packs/projects/%s/installed", c.cfg.ProjectID)
+	path := fmt.Sprintf("/api/schemas/projects/%s/installed", c.cfg.ProjectID)
 	data, err := c.do(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("list installed schemas: %w", err)
@@ -28,7 +28,7 @@ type InstallSchemaRequest struct {
 // This is a two-step operation: create in registry, then assign to project.
 func (c *Client) InstallSchema(ctx context.Context, req InstallSchemaRequest) error {
 	// Step 1: Create schema in org registry.
-	data, err := c.do(ctx, http.MethodPost, "/api/template-packs", req)
+	data, err := c.do(ctx, http.MethodPost, "/api/schemas", req)
 	if err != nil {
 		return fmt.Errorf("create schema in registry: %w", err)
 	}
@@ -43,9 +43,11 @@ func (c *Client) InstallSchema(ctx context.Context, req InstallSchemaRequest) er
 		return fmt.Errorf("schema creation response missing id")
 	}
 
-	// Step 2: Assign to project with merge=true.
-	assignPath := fmt.Sprintf("/api/template-packs/projects/%s/assign?merge=true", c.cfg.ProjectID)
-	assignReq := map[string]string{"template_pack_id": schemaID}
+	// Step 2: Assign to project with merge=true. The merge flag must be in the
+	// request body: the endpoint binds AssignPackRequest from the POST body and
+	// ignores query parameters.
+	assignPath := fmt.Sprintf("/api/schemas/projects/%s/assign", c.cfg.ProjectID)
+	assignReq := map[string]any{"schema_id": schemaID, "merge": true}
 	_, err = c.do(ctx, http.MethodPost, assignPath, assignReq)
 	if err != nil {
 		return fmt.Errorf("assign schema to project: %w", err)
@@ -56,7 +58,7 @@ func (c *Client) InstallSchema(ctx context.Context, req InstallSchemaRequest) er
 
 // UninstallSchema removes a schema assignment from the project.
 func (c *Client) UninstallSchema(ctx context.Context, assignmentID string) error {
-	path := fmt.Sprintf("/api/template-packs/projects/%s/assignments/%s", c.cfg.ProjectID, assignmentID)
+	path := fmt.Sprintf("/api/schemas/projects/%s/assignments/%s", c.cfg.ProjectID, assignmentID)
 	_, err := c.do(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return fmt.Errorf("uninstall schema %s: %w", assignmentID, err)


### PR DESCRIPTION
The memory server renamed the template-pack concept to schemas (migration `00058_rename_schema_terminology`): routes moved from `/api/template-packs/*` to `/api/schemas/*` and the assign field from `template_pack_id` to `schema_id`, with no backward-compat alias. The two memory clients in this repo were never fully migrated, so `ListInstalledSchemas` 404s at server startup ("semantic schema verification failed") and `InstallSchema`/`UninstallSchema` cannot work.

Changes:
- `strategy-server/internal/memory/schemas.go`: new paths + `schema_id` in the assign body
- `epf-cli/internal/memory/schemas.go`: new paths (this client already sent `schema_id`)
- Both: `merge=true` moved from query parameter into the POST body. The assign endpoint binds `AssignPackRequest` from the body and ignores query parameters, so the flag was being silently dropped
- Tests updated; added `TestInstallSchema` pinning path, field name, and merge-in-body

Verified against a live emergent.memory instance: old path 404, new path 200, and strategy-server startup now logs `semantic: verified Memory schemas`.

Note: emergent.memory's own CLI has one remaining old-path call (`tools/cli/internal/cmd/auth.go:1222`), happy to send a separate PR there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pazyPDeq8gpRioASbSmaM