### PR TITLE
fix(llm): compatibility with reasoning-family models (gpt-5.x, o-series)

### DIFF
--- a/apps/strategy-server/internal/llm/client.go
+++ b/apps/strategy-server/internal/llm/client.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -230,6 +231,14 @@ type Client struct {
 	completionsPath string
 	model           string
 	httpClient      *http.Client
+
+	// Reasoning-family models (gpt-5.x, o-series) reject the legacy
+	// max_tokens parameter and non-default temperature values. These flags
+	// flip on the first such rejection and the request is retried with the
+	// adjusted shape, so older models, Ollama, and Vertex keep their exact
+	// behavior while newer models adapt automatically.
+	useMaxCompletionTokens atomic.Bool
+	defaultTemperatureOnly atomic.Bool
 }
 
 // New creates a new LLM client. Returns nil if baseURL is empty.
@@ -272,11 +281,15 @@ var FormatText = &ResponseFormat{Type: "text"}
 
 // chatRequest is the OpenAI chat completions request format.
 type chatRequest struct {
-	Model          string          `json:"model"`
-	Messages       []ChatMessage   `json:"messages"`
-	Temperature    float64         `json:"temperature,omitempty"`
-	MaxTokens      int             `json:"max_tokens,omitempty"`
-	ResponseFormat *ResponseFormat `json:"response_format,omitempty"`
+	Model       string        `json:"model"`
+	Messages    []ChatMessage `json:"messages"`
+	Temperature float64       `json:"temperature,omitempty"`
+	MaxTokens   int           `json:"max_tokens,omitempty"`
+	// MaxCompletionTokens replaces MaxTokens for reasoning-family models
+	// (gpt-5.x, o-series). Populated by the client's adaptation logic in
+	// do(); callers should keep setting MaxTokens.
+	MaxCompletionTokens int             `json:"max_completion_tokens,omitempty"`
+	ResponseFormat      *ResponseFormat `json:"response_format,omitempty"`
 }
 
 // ChatMessage represents a single message in a chat conversation.
@@ -332,10 +345,13 @@ func (c *Client) Chat(ctx context.Context, messages []ChatMessage, temperature f
 // provider will accept generation requests (the project may be denied or
 // suspended). Callers should pass a context with a short timeout.
 func (c *Client) Ping(ctx context.Context) error {
+	// 128 rather than 1: reasoning-family models (gpt-5.x, o-series) spend
+	// completion budget on reasoning tokens before any output, and reject
+	// the request outright when the cap is too small to ever produce text.
 	_, err := c.do(ctx, chatRequest{
 		Model:     c.model,
 		Messages:  []ChatMessage{{Role: "user", Content: "ping"}},
-		MaxTokens: 1,
+		MaxTokens: 128,
 	})
 	return err
 }
@@ -366,7 +382,49 @@ func (c *Client) setAuthHeader(req *http.Request) error {
 	return nil
 }
 
+// do executes a chat request, transparently adapting the request shape for
+// reasoning-family models (gpt-5.x, o-series): those reject the legacy
+// max_tokens parameter (HTTP 400 pointing at max_completion_tokens) and any
+// non-default temperature. On the first such rejection the corresponding
+// sticky flag is set and the request is retried once, so subsequent calls
+// send the right shape immediately. Providers that accept the legacy shape
+// (older OpenAI models, Ollama, Vertex) never trigger the adaptation.
 func (c *Client) do(ctx context.Context, req chatRequest) (*ChatResult, error) {
+	for attempt := 0; ; attempt++ {
+		adjusted := req
+		if c.useMaxCompletionTokens.Load() && adjusted.MaxTokens > 0 {
+			adjusted.MaxCompletionTokens = adjusted.MaxTokens
+			adjusted.MaxTokens = 0
+		}
+		if c.defaultTemperatureOnly.Load() {
+			adjusted.Temperature = 0 // omitempty drops it → provider default
+		}
+
+		result, err := c.doOnce(ctx, adjusted)
+		// Allow at most one retry per adaptable parameter.
+		if err == nil || attempt >= 2 {
+			return result, err
+		}
+
+		var apiErr *APIError
+		if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusBadRequest {
+			return result, err
+		}
+
+		switch {
+		case !c.useMaxCompletionTokens.Load() && adjusted.MaxTokens > 0 &&
+			strings.Contains(apiErr.Message, "max_completion_tokens"):
+			c.useMaxCompletionTokens.Store(true)
+		case !c.defaultTemperatureOnly.Load() && adjusted.Temperature != 0 &&
+			strings.Contains(apiErr.Message, "'temperature'"):
+			c.defaultTemperatureOnly.Store(true)
+		default:
+			return result, err
+		}
+	}
+}
+
+func (c *Client) doOnce(ctx context.Context, req chatRequest) (*ChatResult, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("marshal chat request: %w", err)

--- a/apps/strategy-server/internal/llm/client_test.go
+++ b/apps/strategy-server/internal/llm/client_test.go
@@ -449,3 +449,78 @@ func TestModelSelector_DefaultReturnsConfiguredModel(t *testing.T) {
 		}
 	}
 }
+
+// TestReasoningModelAdaptation verifies the client self-heals against
+// reasoning-family models (gpt-5.x, o-series) that reject the legacy
+// max_tokens parameter and non-default temperature values, and that the
+// adaptation is sticky (subsequent calls send the adapted shape immediately).
+func TestReasoningModelAdaptation(t *testing.T) {
+	okBody := `{"choices":[{"message":{"content":"pong"}}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`
+
+	var calls int
+	var requests []chatRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		var req chatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		requests = append(requests, req)
+
+		w.Header().Set("Content-Type", "application/json")
+		if req.MaxTokens > 0 {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"error":{"message":"Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead."}}`))
+			return
+		}
+		if req.Temperature != 0 {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"error":{"message":"Unsupported value: 'temperature' does not support 0.2 with this model. Only the default (1) value is supported."}}`))
+			return
+		}
+		w.Write([]byte(okBody))
+	}))
+	defer server.Close()
+
+	client := New(Config{BaseURL: server.URL, APIKey: "test-key", Model: "gpt-5.5"})
+
+	// Ping sets MaxTokens: first call is rejected, retry must carry
+	// max_completion_tokens instead.
+	if err := client.Ping(context.Background()); err != nil {
+		t.Fatalf("ping should succeed after adaptation: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("calls=%d after Ping, want 2 (reject + adapted retry)", calls)
+	}
+	if requests[1].MaxTokens != 0 || requests[1].MaxCompletionTokens != requests[0].MaxTokens {
+		t.Errorf("retry request: max_tokens=%d max_completion_tokens=%d, want 0/%d",
+			requests[1].MaxTokens, requests[1].MaxCompletionTokens, requests[0].MaxTokens)
+	}
+
+	// Chat with a custom temperature: rejected once, then retried without it.
+	result, err := client.Chat(context.Background(), []ChatMessage{{Role: "user", Content: "ping"}}, 0.2)
+	if err != nil {
+		t.Fatalf("chat should succeed after temperature adaptation: %v", err)
+	}
+	if result.Content != "pong" {
+		t.Errorf("content=%q, want pong", result.Content)
+	}
+	if calls != 4 {
+		t.Fatalf("calls=%d after Chat, want 4 (temp reject + adapted retry)", calls)
+	}
+	if requests[3].Temperature != 0 {
+		t.Errorf("retry request still carries temperature=%v", requests[3].Temperature)
+	}
+
+	// Stickiness: both adaptations remembered — next Ping succeeds first try.
+	if err := client.Ping(context.Background()); err != nil {
+		t.Fatalf("second ping: %v", err)
+	}
+	if calls != 5 {
+		t.Fatalf("calls=%d after second Ping, want 5 (no extra rejection roundtrip)", calls)
+	}
+	if requests[4].MaxCompletionTokens == 0 || requests[4].MaxTokens != 0 {
+		t.Errorf("sticky request: max_tokens=%d max_completion_tokens=%d, want 0/nonzero",
+			requests[4].MaxTokens, requests[4].MaxCompletionTokens)
+	}
+}


### PR DESCRIPTION
The OpenAI-compatible LLM client fails against current reasoning-family models (gpt-5.x, o-series) three ways, which makes the preflight and all LLM-backed features unusable with e.g. `gpt-5.5`:

- the legacy `max_tokens` parameter is rejected (HTTP 400: "Use 'max_completion_tokens' instead")
- any non-default `temperature` is rejected ("Only the default (1) value is supported")
- `Ping` budgets exactly 1 completion token, which a reasoning model can never satisfy: the completion budget is consumed by reasoning tokens before any output text is produced

**Fix: self-healing adaptation instead of model-name matching.** On the first rejection of each kind the client sets a sticky flag, adjusts the request (moves `MaxTokens` into `max_completion_tokens`; drops the custom temperature), and retries once. Subsequent calls send the adapted shape immediately. Providers that accept the legacy shape (older OpenAI models, Ollama, Vertex) never trigger the adaptation and keep their exact behavior, no configuration added. `Ping`'s budget is raised to 128 tokens.

`TestReasoningModelAdaptation` covers both rejections, the adapted retries, and stickiness across calls.

Verified live against `api.openai.com` with `gpt-5.5`: startup preflight logs `llm provider enabled and reachable (preflight ok)` and `/health` reports `llm: ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pazyPDeq8gpRioASbSmaM